### PR TITLE
Prevent race condition for lookups

### DIFF
--- a/NSObject+Rx.swift
+++ b/NSObject+Rx.swift
@@ -14,18 +14,18 @@ public extension NSObject {
 
     var rx_disposeBag: DisposeBag {
         get {
-            var lookup: DisposeBag?
+            var disposeBag: DisposeBag?
             doLocked {
-                lookup = objc_getAssociatedObject(self, &AssociatedKeys.DisposeBag) as? DisposeBag
+                let lookup = objc_getAssociatedObject(self, &AssociatedKeys.DisposeBag) as? DisposeBag
+                if let lookup = lookup {
+                    disposeBag = lookup
+                } else {
+                    let newDisposeBag = DisposeBag()
+                    self.rx_disposeBag = newDisposeBag
+                    disposeBag = newDisposeBag
+                }
             }
-
-            guard let disposeBag = lookup else {
-                let newDisposeBag = DisposeBag()
-                self.rx_disposeBag = newDisposeBag
-                return newDisposeBag
-            }
-
-            return disposeBag
+            return disposeBag!
         }
 
         set {


### PR DESCRIPTION
There is a possible scenario for a race condition when doing lookups in the existing code from multiple threads.

1) T1 tries to do a lookup, acquires lock, but doesn't find anything
2) T2 tries to do a lookup, fails to acquire lock, waits while T1 releases lock
3) T1 releases lock and leaves the critical section without a lookup
4) T2 acquires the lock, tries to do a lookup, finds nothing, leaves critical section without a lookup
5) T1 finally creates a disposable bag
6) T2 creates a disposable bag too, overwrites disposable bag from T1

The suggested solution does both the lookup and assignment in the same critical section.

(Sorry about the force unwrapped optional!)
