### PR TITLE
Added rx_observableForSelector to NSObject

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -12,8 +12,10 @@
 		5E9E83241BF79B3000C85B46 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5E9E83221BF79B3000C85B46 /* Main.storyboard */; };
 		5E9E83261BF79B3000C85B46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5E9E83251BF79B3000C85B46 /* Assets.xcassets */; };
 		5E9E83291BF79B3000C85B46 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5E9E83271BF79B3000C85B46 /* LaunchScreen.storyboard */; };
-		5E9E83341BF79B3000C85B46 /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9E83331BF79B3000C85B46 /* DemoTests.swift */; };
-		ADC6692B4109DB302AB40A30 /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DF46C3E339DF3F38052433E /* Pods_DemoTests.framework */; };
+		770C7C0C2F963D75CE0EA8B8 /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62DA96B6E4DA1307DBD4C79E /* Pods_DemoTests.framework */; };
+		8472DC331CBE867F00522DEB /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9E83331BF79B3000C85B46 /* DemoTests.swift */; };
+		8472DC351CBE874D00522DEB /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8472DC341CBE874D00522DEB /* Mock.swift */; };
+		C52016E76ED158114131A339 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AA25D15D05B6CB79B8C0D18 /* Pods_Demo.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,9 +29,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0DF46C3E339DF3F38052433E /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F79F878C5E2083EFB22AA39 /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		5C9BC35B3BC2F649D5FF6AE4 /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		249E477824F0273A43B271F3 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
+		27EE503A17890D1120C5132D /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		4AA25D15D05B6CB79B8C0D18 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E9E831B1BF79B3000C85B46 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E9E831E1BF79B3000C85B46 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5E9E83201BF79B3000C85B46 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -40,6 +42,10 @@
 		5E9E832F1BF79B3000C85B46 /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E9E83331BF79B3000C85B46 /* DemoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
 		5E9E83351BF79B3000C85B46 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		62DA96B6E4DA1307DBD4C79E /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8472DC341CBE874D00522DEB /* Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
+		AEDD0DC240FEA58D710665A6 /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		FC1EC6C816F6F28278F6FA99 /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -47,6 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C52016E76ED158114131A339 /* Pods_Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -54,19 +61,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ADC6692B4109DB302AB40A30 /* Pods_DemoTests.framework in Frameworks */,
+				770C7C0C2F963D75CE0EA8B8 /* Pods_DemoTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2A82831F9249057F52A52F41 /* Frameworks */ = {
+		5CAA70591240F786F3038862 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				0DF46C3E339DF3F38052433E /* Pods_DemoTests.framework */,
+				27EE503A17890D1120C5132D /* Pods-Demo.debug.xcconfig */,
+				249E477824F0273A43B271F3 /* Pods-Demo.release.xcconfig */,
+				FC1EC6C816F6F28278F6FA99 /* Pods-DemoTests.debug.xcconfig */,
+				AEDD0DC240FEA58D710665A6 /* Pods-DemoTests.release.xcconfig */,
 			);
-			name = Frameworks;
+			name = Pods;
 			sourceTree = "<group>";
 		};
 		5E9E83121BF79B3000C85B46 = {
@@ -75,8 +85,8 @@
 				5E9E831D1BF79B3000C85B46 /* Demo */,
 				5E9E83321BF79B3000C85B46 /* DemoTests */,
 				5E9E831C1BF79B3000C85B46 /* Products */,
-				A3610BA6ACDCBE0B5A6A2595 /* Pods */,
-				2A82831F9249057F52A52F41 /* Frameworks */,
+				5CAA70591240F786F3038862 /* Pods */,
+				B2B1B9F944C7D9EB65E0D23C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -106,18 +116,19 @@
 			isa = PBXGroup;
 			children = (
 				5E9E83331BF79B3000C85B46 /* DemoTests.swift */,
+				8472DC341CBE874D00522DEB /* Mock.swift */,
 				5E9E83351BF79B3000C85B46 /* Info.plist */,
 			);
 			path = DemoTests;
 			sourceTree = "<group>";
 		};
-		A3610BA6ACDCBE0B5A6A2595 /* Pods */ = {
+		B2B1B9F944C7D9EB65E0D23C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				2F79F878C5E2083EFB22AA39 /* Pods-DemoTests.debug.xcconfig */,
-				5C9BC35B3BC2F649D5FF6AE4 /* Pods-DemoTests.release.xcconfig */,
+				4AA25D15D05B6CB79B8C0D18 /* Pods_Demo.framework */,
+				62DA96B6E4DA1307DBD4C79E /* Pods_DemoTests.framework */,
 			);
-			name = Pods;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -127,9 +138,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5E9E83381BF79B3000C85B46 /* Build configuration list for PBXNativeTarget "Demo" */;
 			buildPhases = (
+				1634342AD18B55F811A34E41 /* 📦 Check Pods Manifest.lock */,
 				5E9E83171BF79B3000C85B46 /* Sources */,
 				5E9E83181BF79B3000C85B46 /* Frameworks */,
 				5E9E83191BF79B3000C85B46 /* Resources */,
+				831B56AF01005BE560B4FE64 /* 📦 Embed Pods Frameworks */,
+				6B480FB49622A94298FBB6F1 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -144,12 +158,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5E9E833B1BF79B3000C85B46 /* Build configuration list for PBXNativeTarget "DemoTests" */;
 			buildPhases = (
-				50CBE397D69CF12004C9DB16 /* Check Pods Manifest.lock */,
+				408D38FD77B3A7E7B54A7675 /* 📦 Check Pods Manifest.lock */,
 				5E9E832B1BF79B3000C85B46 /* Sources */,
 				5E9E832C1BF79B3000C85B46 /* Frameworks */,
 				5E9E832D1BF79B3000C85B46 /* Resources */,
-				DA043BB05F48FB36A496F8EF /* Embed Pods Frameworks */,
-				C27372C1B4E183C3FA9519EE /* Copy Pods Resources */,
+				EF5570FF2F178816375908A7 /* 📦 Embed Pods Frameworks */,
+				FF5074287A86AC153BBED54C /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -219,14 +233,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		50CBE397D69CF12004C9DB16 /* Check Pods Manifest.lock */ = {
+		1634342AD18B55F811A34E41 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -234,34 +248,79 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		C27372C1B4E183C3FA9519EE /* Copy Pods Resources */ = {
+		408D38FD77B3A7E7B54A7675 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		DA043BB05F48FB36A496F8EF /* Embed Pods Frameworks */ = {
+		6B480FB49622A94298FBB6F1 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Demo/Pods-Demo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		831B56AF01005BE560B4FE64 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EF5570FF2F178816375908A7 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FF5074287A86AC153BBED54C /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -280,7 +339,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5E9E83341BF79B3000C85B46 /* DemoTests.swift in Sources */,
+				8472DC331CBE867F00522DEB /* DemoTests.swift in Sources */,
+				8472DC351CBE874D00522DEB /* Mock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -397,6 +457,7 @@
 		};
 		5E9E83391BF79B3000C85B46 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 27EE503A17890D1120C5132D /* Pods-Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -409,6 +470,7 @@
 		};
 		5E9E833A1BF79B3000C85B46 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 249E477824F0273A43B271F3 /* Pods-Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -421,7 +483,7 @@
 		};
 		5E9E833C1BF79B3000C85B46 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2F79F878C5E2083EFB22AA39 /* Pods-DemoTests.debug.xcconfig */;
+			baseConfigurationReference = FC1EC6C816F6F28278F6FA99 /* Pods-DemoTests.debug.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = DemoTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -432,7 +494,7 @@
 		};
 		5E9E833D1BF79B3000C85B46 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5C9BC35B3BC2F649D5FF6AE4 /* Pods-DemoTests.release.xcconfig */;
+			baseConfigurationReference = AEDD0DC240FEA58D710665A6 /* Pods-DemoTests.release.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = DemoTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Demo/DemoTests/DemoTests.swift
+++ b/Demo/DemoTests/DemoTests.swift
@@ -2,6 +2,7 @@ import Quick
 import Nimble
 import RxSwift
 import NSObject_Rx
+import Foundation
 
 class Test: QuickSpec {
     override func spec() {
@@ -29,5 +30,235 @@ class Test: QuickSpec {
             variable.onNext(1)
             expect(executed) == false
         }
+        
+        it("should have same observable for same selector") {
+            let mock = Mock()
+            let observable1 = mock.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+            let observable2 = mock.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+            
+            expect(observable1) === observable2
+        }
+        
+        it("should have different observables for different selectors") { 
+            let mock = Mock()
+            let observable1 = mock.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+            let observable2 = mock.rx_observableForSelector(#selector(Mock.funcWithParamsReturnsVoid(_:)))
+            
+            expect(observable1) !== observable2
+        }
+        
+        it("observes selector for method without params") {
+            var completed = false
+            var nextCalled = false
+            var mock: Mock? = Mock()
+            
+            _ = mock?.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+                .subscribe { (event) in
+                    switch event {
+                    case .Next:
+                        nextCalled = true
+                    case .Completed:
+                        completed = true
+                    default : break
+                    }
+            }
+            mock?.funcWithOutParams()
+            mock = nil
+            expect(completed) == true
+            expect(nextCalled) == true
+        }
+        
+        it("observes selector for method which returns bool") {
+            var completed = false
+            var nextCalled = false
+            var mock: Mock? = Mock()
+            
+            _ = mock?.rx_observableForSelector(#selector(Mock.funcWhichReturnsBool))
+                .subscribe { (event) in
+                    switch event {
+                    case .Next:
+                        nextCalled = true
+                    case .Completed:
+                        completed = true
+                    default : break
+                    }
+            }
+            _ = mock?.funcWhichReturnsBool()
+            mock = nil
+            expect(completed) == true
+            expect(nextCalled) == true
+        }
+        
+        it("observes selector for method which returns object") { 
+            var completed = false
+            var nextCalled = false
+            var mock: Mock? = Mock()
+            
+            _ = mock?.rx_observableForSelector(#selector(Mock.funcWithParamsReturnsParam(_:)))
+                .subscribe { (event) in
+                    switch event {
+                    case .Next:
+                        nextCalled = true
+                    case .Completed:
+                        completed = true
+                    default : break
+                    }
+            }
+            _ = mock?.funcWithParamsReturnsParam(1)
+            mock = nil
+            expect(completed) == true
+            expect(nextCalled) == true
+        }
+        
+        it("calls observed method") { 
+            var completed = false
+            var nextCalled = false
+            var methodCalled = false
+            var mock: Mock? = Mock()
+            
+            _ = mock?.rx_observableForSelector(#selector(Mock.funcWithClosure(_:)))
+                .subscribe { (event) in
+                    switch event {
+                    case .Next:
+                        nextCalled = true
+                    case .Completed:
+                        completed = true
+                    default : break
+                    }
+            }
+            _ = mock?.funcWithClosure({ 
+                methodCalled = true
+            })
+            mock = nil
+            expect(completed) == true
+            expect(nextCalled) == true
+            expect(methodCalled) == true
+        }
+        
+        it("send next every time method invoked") { 
+            var completed = false
+            var count = 0
+            var mock: Mock? = Mock()
+            
+            _ = mock?.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+                .subscribe { (event) in
+                    switch event {
+                    case .Next:
+                        count += 1
+                    case .Completed:
+                        completed = true
+                    default : break
+                    }
+            }
+            mock?.funcWithOutParams()
+            mock?.funcWithOutParams()
+            mock = nil
+            expect(completed) == true
+            expect(count) == 2
+        }
+        
+        it("send events when perform selector called") {
+            var completed = false
+            var nextCalled = false
+            var mock: Mock? = Mock()
+            
+            _ = mock?.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+                .subscribe { (event) in
+                    switch event {
+                    case .Next:
+                        nextCalled = true
+                    case .Completed:
+                        completed = true
+                    default : break
+                    }
+            }
+            mock?.performSelector(#selector(Mock.funcWithOutParams))
+            mock = nil
+            expect(completed) == true
+            expect(nextCalled) == true
+        }
+        
+        it("should send events for KVO'd object") { 
+            var completed = false
+            var nextCalled = false
+            let numberToChange: NSNumber = 2
+            var numberChanged: NSNumber?
+            var mock: Mock? = Mock()
+            
+            _ = mock?.rx_observeWeakly(NSNumber.self, "number", options: [.New])
+                .subscribeNext({ (n) in
+                    numberChanged = n
+                })
+            
+            _ = mock?.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+                .subscribe { (event) in
+                    switch event {
+                    case .Next:
+                        nextCalled = true
+                    case .Completed:
+                        completed = true
+                    default : break
+                    }
+            }
+            _ = mock?.rx_deallocating.subscribeNext {
+                print("")
+            }
+            
+            mock?.number = numberToChange
+            mock?.funcWithOutParams()
+            
+            expect(numberChanged).toNot(beNil())
+            expect(numberChanged) == numberToChange
+            
+            mock = nil
+            
+            expect(completed) == true
+            expect(nextCalled) == true
+        }
+ 
+        it("responds to original selector") {
+            let mock = Mock()
+            _ = mock.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+            
+            expect(mock.respondsToSelector(#selector(Mock.funcWithOutParams))) == true
+        }
+        
+        it("is member of class") { 
+            let mock = Mock()
+            _ = mock.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+            
+            expect(mock.isKindOfClass(Mock)) == true
+        }
+        
+        it("is member of the same class") { 
+            let mock = Mock()
+            _ = mock.rx_observableForSelector(#selector(Mock.funcWithOutParams))
+            
+            expect(mock.isMemberOfClass(Mock)) == true
+        }
+        
+        it("sends error if object does not respond to selector") { 
+            let mock = Mock()
+            var error: ErrorType?
+            var nextCalled = false
+            var completed = false
+            _ = mock.rx_observableForSelector(#selector(NSMutableArray.addObject(_:)))
+                .subscribe({ (event) in
+                    switch event {
+                    case .Next:
+                        nextCalled = true
+                    case .Error(let err):
+                        error = err
+                    case .Completed:
+                        completed = false
+                    }
+                })
+            mock.funcWithOutParams()
+            
+            expect(error).toNot(beNil())
+            expect(nextCalled) == false
+            expect(completed) == false
+        }
+        
     }
 }

--- a/Demo/DemoTests/Mock.swift
+++ b/Demo/DemoTests/Mock.swift
@@ -1,0 +1,37 @@
+//
+//  Mock.swift
+//  Demo
+//
+//  Created by Segii Shulga on 4/13/16.
+//  Copyright © 2016 Ash Furrow. All rights reserved.
+//
+
+import Foundation
+
+class Mock: NSObject {
+    dynamic var number: NSNumber = 1
+    
+    dynamic func funcWithOutParams() {
+        print("funcWithOutParams")
+    }
+    
+    dynamic func funcWhichReturnsBool() -> Bool {
+        return false
+    }
+    
+    dynamic func funcWithParamsReturnsVoid(param: AnyObject) {
+    }
+    
+    dynamic func funcWithParamsReturnsParam(param: AnyObject) -> AnyObject {
+        return param
+    }
+    
+    dynamic func funcWithClosure(closure: () -> ()) {
+        closure()
+    }
+    
+    deinit {
+        print("deinit self")
+    }
+    
+}

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,24 +1,30 @@
 PODS:
-  - Nimble (3.0.0)
-  - NSObject+Rx (1.1.0):
-    - RxSwift (~> 2.0.0-beta)
+  - Nimble (4.0.0)
+  - NSObject+Rx (1.2.1):
+    - RxCocoa (~> 2.1)
+    - RxSwift (~> 2.1)
   - Quick (0.8.0)
-  - RxSwift (2.0.0-beta.3)
+  - RxCocoa (2.3.1):
+    - RxSwift (~> 2.3.1)
+  - RxSwift (2.3.1)
 
 DEPENDENCIES:
   - Nimble
   - NSObject+Rx (from `../`)
   - Quick
-  - RxSwift (~> 2.0.0-beta)
+  - RxSwift
 
 EXTERNAL SOURCES:
   NSObject+Rx:
     :path: ../
 
 SPEC CHECKSUMS:
-  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
-  NSObject+Rx: eea37e77618589082df56a0e2e092bd0fa237125
+  Nimble: 72bcc3e2f02242e6bfaaf8d9412ca7bfe3d8b417
+  NSObject+Rx: 20306e32fde69d2996ca35edeb29977ab551e7ae
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  RxSwift: 19fbe885b404d1d36d42ac8535134739a9b42952
+  RxCocoa: a2baaf3462b989559a51dce59d78fbebb8fe0afa
+  RxSwift: 829b2843e9eddc77a02cb3f5117f0d55f8f646f1
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 4f420ecd33a82075e360098bbed0ccaadfeb1728
+
+COCOAPODS: 1.0.0.beta.6

--- a/NSObject+Rx.podspec
+++ b/NSObject+Rx.podspec
@@ -16,7 +16,8 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.source       = { :git => "https://github.com/RxSwiftCommunity/NSObject-Rx.git", :tag => s.version }
-  s.source_files  = "*.swift"
+  s.source_files  = "*.{swift,h,m}"
   s.frameworks  = "Foundation"
   s.dependency "RxSwift", '~> 2.1'
+  s.dependency 'RxCocoa', '~> 2.1'
 end

--- a/NSObject+Rx.swift
+++ b/NSObject+Rx.swift
@@ -34,4 +34,24 @@ public extension NSObject {
             }
         }
     }
+    /**
+     Creates a observable associated with the receiver, which will send event
+     each time the given selector is invoked
+     
+     
+     - parameter selector: The selector for whose invocations are to be observed
+     
+     - returns: Observable which will propagate event every time invocation of the selector,
+     then completes when the receiver is deallocated. 
+     If object does not respond to selector returns Observable which fails
+     */
+    func rx_observableForSelector(selector: Selector) -> Observable<Void> {
+        if !self.respondsToSelector(selector) {
+            let message = "Object \(self) does not respond to selector \(selector)"
+            return Observable.error(NSError(domain: "RxSelectorObservableErrorDomain",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey : message]))
+        }
+        return RxSubjectForSelector(self, selector: selector)
+    }
 }

--- a/RxSubjectForSelector.swift
+++ b/RxSubjectForSelector.swift
@@ -1,0 +1,55 @@
+//
+//  RxSubjectForSelector.swift
+//  Pods
+//
+//  Created by Segii Shulga on 4/13/16.
+//
+//
+
+import class RxSwift.Observable
+import class RxSwift.PublishSubject
+import RxCocoa
+
+private struct AssociationKey {
+    static var subjectsDictionaryAssosiatedKey = "RXSubjectsDictionaryAssosiatedKey"
+}
+
+func RxSubjectForSelector(host: NSObject, selector: Selector) -> PublishSubject<Void> {
+    objc_sync_enter(host); defer { objc_sync_exit(host) }
+    let aliasSelector = RxAliasForSelector(selector)
+    
+    return lazySubjectForSelector(host, selector: aliasSelector, factory: { _ -> PublishSubject<Void> in
+        let subject = PublishSubject<Void>()
+        let clas: AnyClass! = RxSwizzleClass(host) { (h, sel) in
+            let subject = RxSubjectForSelector(h as! NSObject, selector: sel)
+            subject.onNext()
+        }
+        let targetMehtod = class_getInstanceMethod(clas, selector)
+        _ = host.rx_deallocating.subscribeNext(subject.onCompleted)
+        RxReplaceMethod(clas, selector, aliasSelector, targetMehtod)
+        
+        return subject
+    })
+}
+
+func lazySubjectForSelector(host: AnyObject, selector: Selector, factory: () -> PublishSubject<Void>) -> PublishSubject<Void> {
+    let selectorsDict = lazyAssociatedProperty(host, key: &AssociationKey.subjectsDictionaryAssosiatedKey) {
+        return NSMutableDictionary()
+    }
+    guard let subject = selectorsDict[selector.description] as? PublishSubject<Void> else {
+        selectorsDict[selector.description] = factory()
+        return lazySubjectForSelector(host, selector: selector, factory: factory)
+    }
+    return subject
+}
+
+func lazyAssociatedProperty<T: AnyObject>(host: AnyObject,
+                            key: UnsafePointer<Void>,
+                            policy: objc_AssociationPolicy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN,
+                            factory: () -> T ) -> T {
+    return objc_getAssociatedObject(host, key) as? T ?? {
+        let associatedProperty = factory()
+        objc_setAssociatedObject(host, key, associatedProperty, policy)
+        return associatedProperty
+    }()
+}

--- a/RxSwizzling.h
+++ b/RxSwizzling.h
@@ -1,0 +1,19 @@
+//
+//  RxSwizzling.h
+//  Pods
+//
+//  Created by Segii Shulga on 4/13/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+typedef void (^RxInvocationCallback)(id host, SEL aliasSelector);
+
+SEL RxAliasForSelector(SEL originalSelector);
+
+Class RxSwizzleClass(NSObject *self, RxInvocationCallback onNext);
+
+void RxReplaceMethod(Class class, SEL selector, SEL aliasSelector, Method method);

--- a/RxSwizzling.m
+++ b/RxSwizzling.m
@@ -1,0 +1,229 @@
+//
+//  RxSwizzling.m
+//  Pods
+//
+//  Created by Segii Shulga on 4/13/16.
+//
+//
+
+#import "RxSwizzling.h"
+
+/* 
+Most of implementation has been taken from RAC.
+For more details https://github.com/ReactiveCocoa/ReactiveCocoa/blob/master/ReactiveCocoa/Objective-C/NSObject%2BRACSelectorSignal.m
+*/
+
+static NSString * const RxObservableForSelectorAliasPrefix = @"rx_alias_";
+static NSString * const RxSubclassSuffix = @"_RxSelectorSubject";
+static void *RxSubclassAssociationKey = &RxSubclassAssociationKey;
+
+static NSMutableSet *swizzledClasses() {
+    static NSMutableSet *set;
+    static dispatch_once_t pred;
+    
+    dispatch_once(&pred, ^{
+        set = [[NSMutableSet alloc] init];
+    });
+    
+    return set;
+}
+
+static BOOL RXForwardInvocation(id self, NSInvocation *invocation, RxInvocationCallback callback) {
+    SEL aliasSelector = RxAliasForSelector(invocation.selector);
+    SEL originalSelector = invocation.selector;
+    
+    Class class = object_getClass(invocation.target);
+    BOOL respondsToAlias = [class instancesRespondToSelector:invocation.selector];
+    if (respondsToAlias) {
+        invocation.selector = aliasSelector;
+        [invocation invoke];
+    }
+    callback(self, originalSelector);
+    return YES;
+}
+
+Method RxGetImmediateInstanceMethod (Class aClass, SEL aSelector) {
+    unsigned methodCount = 0;
+    Method *methods = class_copyMethodList(aClass, &methodCount);
+    Method foundMethod = NULL;
+    
+    for (unsigned methodIndex = 0;methodIndex < methodCount;++methodIndex) {
+        if (method_getName(methods[methodIndex]) == aSelector) {
+            foundMethod = methods[methodIndex];
+            break;
+        }
+    }
+    
+    free(methods);
+    return foundMethod;
+}
+
+
+static void RxSwizzleForwardInvocation(Class class, RxInvocationCallback callback) {
+    SEL forwardInvocationSEL = @selector(forwardInvocation:);
+    Method forwardInvocationMethod = class_getInstanceMethod(class, forwardInvocationSEL);
+    
+        // Preserve any existing implementation of -forwardInvocation:.
+    void (*originalForwardInvocation)(id, SEL, NSInvocation *) = NULL;
+    if (forwardInvocationMethod != NULL) {
+        originalForwardInvocation = (__typeof__(originalForwardInvocation))method_getImplementation(forwardInvocationMethod);
+    }
+    
+    id newForwardInvocation = ^(id self, NSInvocation *invocation) {
+        BOOL matched = RXForwardInvocation(self, invocation, callback);
+        if (matched) return;
+        
+        if (originalForwardInvocation == NULL) {
+            [self doesNotRecognizeSelector:invocation.selector];
+        } else {
+            originalForwardInvocation(self, forwardInvocationSEL, invocation);
+        }
+    };
+    
+    class_replaceMethod(class, forwardInvocationSEL, imp_implementationWithBlock(newForwardInvocation), "v@:@");
+}
+
+static void RxSwizzleRespondsToSelector(Class class) {
+    SEL respondsToSelectorSEL = @selector(respondsToSelector:);
+    
+        // Preserve existing implementation of -respondsToSelector:.
+    Method respondsToSelectorMethod = class_getInstanceMethod(class, respondsToSelectorSEL);
+    BOOL (*originalRespondsToSelector)(id, SEL, SEL) = (__typeof__(originalRespondsToSelector))method_getImplementation(respondsToSelectorMethod);
+    
+    id newRespondsToSelector = ^ BOOL (id self, SEL selector) {
+        Method method = RxGetImmediateInstanceMethod(class, selector);
+        
+        if (method != NULL && method_getImplementation(method) == _objc_msgForward) {
+            SEL aliasSelector = RxAliasForSelector(selector);
+            if (objc_getAssociatedObject(self, aliasSelector) != nil) return YES;
+        }
+        
+        return originalRespondsToSelector(self, respondsToSelectorSEL, selector);
+    };
+    
+    class_replaceMethod(class, respondsToSelectorSEL, imp_implementationWithBlock(newRespondsToSelector), method_getTypeEncoding(respondsToSelectorMethod));
+}
+
+static void RxSwizzleGetClass(Class class, Class statedClass) {
+    SEL selector = @selector(class);
+    Method method = class_getInstanceMethod(class, selector);
+    IMP newIMP = imp_implementationWithBlock(^(id self) {
+        return statedClass;
+    });
+    class_replaceMethod(class, selector, newIMP, method_getTypeEncoding(method));
+}
+
+static void RxSwizzleMethodSignatureForSelector(Class class) {
+    IMP newIMP = imp_implementationWithBlock(^(id self, SEL selector) {
+            // Don't send the -class message to the receiver because we've changed
+            // that to return the original class.
+        Class actualClass = object_getClass(self);
+        Method method = class_getInstanceMethod(actualClass, selector);
+        if (method == NULL) {
+                // Messages that the original class dynamically implements fall
+                // here.
+                //
+                // Call the original class' -methodSignatureForSelector:.
+            struct objc_super target = {
+                .super_class = class_getSuperclass(class),
+                .receiver = self,
+            };
+            NSMethodSignature * (*messageSend)(struct objc_super *, SEL, SEL) = (__typeof__(messageSend))objc_msgSendSuper;
+            return messageSend(&target, @selector(methodSignatureForSelector:), selector);
+        }
+        
+        char const *encoding = method_getTypeEncoding(method);
+        return [NSMethodSignature signatureWithObjCTypes:encoding];
+    });
+    
+    SEL selector = @selector(methodSignatureForSelector:);
+    Method methodSignatureForSelectorMethod = class_getInstanceMethod(class, selector);
+    class_replaceMethod(class, selector, newIMP, method_getTypeEncoding(methodSignatureForSelectorMethod));
+}
+
+// It's hard to tell which struct return types use _objc_msgForward, and
+// which use _objc_msgForward_stret instead, so just exclude all struct, array,
+// union, complex and vector return types.
+static void RxCheckTypeEncoding(const char *typeEncoding) {
+#if !NS_BLOCK_ASSERTIONS
+// Some types, including vector types, are not encoded. In these cases the
+// signature starts with the size of the argument frame.
+    NSCAssert(*typeEncoding < '1' || *typeEncoding > '9', @"unknown method return type not supported in type encoding: %s", typeEncoding);
+    NSCAssert(strstr(typeEncoding, "(") != typeEncoding, @"union method return type not supported");
+    NSCAssert(strstr(typeEncoding, "{") != typeEncoding, @"struct method return type not supported");
+    NSCAssert(strstr(typeEncoding, "[") != typeEncoding, @"array method return type not supported");
+    NSCAssert(strstr(typeEncoding, @encode(_Complex float)) != typeEncoding, @"complex float method return type not supported");
+    NSCAssert(strstr(typeEncoding, @encode(_Complex double)) != typeEncoding, @"complex double method return type not supported");
+    NSCAssert(strstr(typeEncoding, @encode(_Complex long double)) != typeEncoding, @"complex long double method return type not supported");
+#endif // !NS_BLOCK_ASSERTIONS
+}
+
+SEL RxAliasForSelector(SEL originalSelector) {
+    NSString *selectorName = NSStringFromSelector(originalSelector);
+    return NSSelectorFromString([RxObservableForSelectorAliasPrefix stringByAppendingString:selectorName]);
+}
+
+Class RxSwizzleClass(NSObject *self, RxInvocationCallback callback) {
+    Class statedClass = self.class;
+    Class baseClass = object_getClass(self);
+    
+    Class knownDynamicSubclass = objc_getAssociatedObject(self, RxSubclassAssociationKey);
+    if (knownDynamicSubclass != Nil) return knownDynamicSubclass;
+    
+    NSString *className = NSStringFromClass(baseClass);
+    
+    if (statedClass != baseClass) {
+        // If the class is already lying about what it is, it's probably a KVO
+        // dynamic subclass or something else that we shouldn't subclass
+        // ourselves.
+        //
+        // Just swizzle -forwardInvocation: in-place. Since the object's class
+        // was almost certainly dynamically changed, we shouldn't see another of
+        // these classes in the hierarchy.
+        //
+        // Additionally, swizzle -respondsToSelector: because the default
+        // implementation may be ignorant of methods added to this class.
+        @synchronized (swizzledClasses()) {
+            if (![swizzledClasses() containsObject:className]) {
+                RxSwizzleForwardInvocation(baseClass, callback);
+                RxSwizzleRespondsToSelector(baseClass);
+                RxSwizzleGetClass(baseClass, statedClass);
+                RxSwizzleGetClass(object_getClass(baseClass), statedClass);
+                RxSwizzleMethodSignatureForSelector(baseClass);
+                [swizzledClasses() addObject:className];
+            }
+        }
+        
+        return baseClass;
+    }
+    
+    const char *subclassName = [className stringByAppendingString:RxSubclassSuffix].UTF8String;
+    Class subclass = objc_getClass(subclassName);
+    
+    if (subclass == nil) {
+        subclass = objc_allocateClassPair(baseClass, subclassName, 0);
+        if (subclass == nil) return nil;
+        
+        RxSwizzleForwardInvocation(subclass, callback);
+        RxSwizzleRespondsToSelector(subclass);
+        
+        RxSwizzleGetClass(subclass, statedClass);
+        RxSwizzleGetClass(object_getClass(subclass), statedClass);
+        
+        RxSwizzleMethodSignatureForSelector(subclass);
+        
+        objc_registerClassPair(subclass);
+    }
+    
+    object_setClass(self, subclass);
+    objc_setAssociatedObject(self, RxSubclassAssociationKey, subclass, OBJC_ASSOCIATION_ASSIGN);
+    return subclass;
+}
+
+void RxReplaceMethod(Class class, SEL selector, SEL aliasSelector, Method method) {
+    if (method_getImplementation(method) != _objc_msgForward) {
+        RxCheckTypeEncoding(method_getTypeEncoding(method));
+        class_addMethod(class, aliasSelector, method_getImplementation(method), method_getTypeEncoding(method));
+        class_replaceMethod(class, selector, _objc_msgForward, method_getTypeEncoding(method));
+    }
+}


### PR DESCRIPTION
Hi, guys I remember we had some [discussion](https://github.com/ReactiveX/RxSwift/issues/181) regarding observing method calls on main Rx repo

Almost all implementation has been taken from [RAC](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/master/ReactiveCocoa/Objective-C/NSObject%2BRACSelectorSignal.m)

I'm still not sure about naming conventions and whether I completely covered implementation with test, and whether you want this feature in this repo :)

But I open for discussion :)
