### PR TITLE
Use a released version instead of a branch.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "develop"
+github "ReactiveX/RxSwift" "3.0.0-beta.1"


### PR DESCRIPTION
Carthage should always use a release instead of a branch in order to
avoid conflicts with other projects that use RxSwift
