### PR TITLE
Allow usage of rx.disposeBag alongside rx_disposeBag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Changelog
 Current master
 --------------
 
-- Nothing yet!
+- Allow usage of rx.disposeBag alongside rx_disposeBag ([#29](https://github.com/RxSwiftCommunity/NSObject-Rx/pull/29)) - [@freak4pc](https://github.com/freak4pc)
 
 2.0.0
 -----

--- a/NSObject+Rx.swift
+++ b/NSObject+Rx.swift
@@ -35,3 +35,9 @@ public extension NSObject {
         }
     }
 }
+
+extension Reactive where Base: NSObject {
+    var disposeBag: DisposeBag {
+        return base.rx_disposeBag
+    }
+}


### PR DESCRIPTION
It seems to me having disposeBag scoped into the `rx.` prefix feel more in-line with the rest of How RxSwift 3.0 behaves, so felt this would be a nice touch-up. Of course totally open to any feedback. 

This allows using `.addDisposableTo(rx.disposeBag)`

Thanks! :-)