### PR TITLE
Fixed titles in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ It'll work just like a property: when the instance is deinit'd, the `DisposeBag`
 Installing
 ----------
 
-####CocoaPods
+#### CocoaPods
 
 This works with RxSwift version 2, which is still prerelease, so you've gotta be fancy with your podfile.
 
@@ -42,7 +42,7 @@ pod 'NSObject+Rx'
 
 And that'll be 👌
 
-####Carthage
+#### Carthage
 
 Add to `Cartfile`:
 ```


### PR DESCRIPTION
This just fixes all markdown titles in the [Readme.md](https://github.com/RxSwiftCommunity/NSObject-Rx/blob/master/Readme.md)
# Changes
Changes look like this: 
```md
##TitleName
<!--- now becomes -->
## TitleName
```
which is the difference between:

>**##TitleName**

_and_
>## TitleName