### PR TITLE
Set APPLICATION_EXTENSION_API_ONLY to YES to resolve warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Changelog
 Current master
 --------------
 
-- Nothing yet!
+- Fixes a warning when used in application extensions. See [#45](https://github.com/RxSwiftCommunity/NSObject-Rx/pull/45) - [@mono0926](https://github.com/mono0926)
 
 3.0.1
 -----

--- a/NSObject-Rx.xcodeproj/project.pbxproj
+++ b/NSObject-Rx.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		188C6D9B1C47B2B20092101A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -181,6 +182,7 @@
 		188C6D9C1C47B2B20092101A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
If this is set to NO, the warning occurs.

> ld: warning: linking against a dylib which is not safe for use in application extensions: /Users/mono/Git/Aquatica/ghost-ios/Carthage/Build/iOS/NSObject_Rx.framework/NSObject_Rx