### PR TITLE
hotfix: RxSwift 4.0 and Carthage ketchup

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 3.0.0
+github "ReactiveX/RxSwift" ~> 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "ReactiveX/RxSwift" "4.0.0"

--- a/NSObject-Rx.xcodeproj/project.pbxproj
+++ b/NSObject-Rx.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		188C6DA31C47B4240092101A /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 188C6DA21C47B4240092101A /* RxSwift.framework */; };
-		5E6ACB5B1F58657A0050E957 /* HasDisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6ACB591F58657A0050E957 /* HasDisposeBag.swift */; };
 		5E6ACB5C1F58657A0050E957 /* NSObject+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6ACB5A1F58657A0050E957 /* NSObject+Rx.swift */; };
 /* End PBXBuildFile section */
 
@@ -16,7 +15,6 @@
 		188C6D911C47B2B20092101A /* NSObject_Rx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NSObject_Rx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		188C6DA21C47B4240092101A /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = SOURCE_ROOT; };
 		1AE62DBF1F50C8230011BA4F /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
-		5E6ACB591F58657A0050E957 /* HasDisposeBag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HasDisposeBag.swift; sourceTree = SOURCE_ROOT; };
 		5E6ACB5A1F58657A0050E957 /* NSObject+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Rx.swift"; sourceTree = SOURCE_ROOT; };
 		FE5EDFCF1F6A2CBF000ABFAC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -36,11 +34,10 @@
 		188C6D921C47B2B20092101A /* NSObject_Rx */ = {
 			isa = PBXGroup;
 			children = (
-				5E6ACB591F58657A0050E957 /* HasDisposeBag.swift */,
 				5E6ACB5A1F58657A0050E957 /* NSObject+Rx.swift */,
 				188C6DA21C47B4240092101A /* RxSwift.framework */,
 			);
-			path = NSObject_Rx;
+			name = NSObject_Rx;
 			sourceTree = "<group>";
 		};
 		18EE7A0F1C47B12F00C7256C = {
@@ -141,7 +138,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5E6ACB5B1F58657A0050E957 /* HasDisposeBag.swift in Sources */,
 				5E6ACB5C1F58657A0050E957 /* NSObject+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Readme.md
+++ b/Readme.md
@@ -48,7 +48,7 @@ And that'll be 👌
 
 Add to `Cartfile`:
 ```
-github "RxSwiftCommunity/NSObject-Rx" ~> 2.0.0
+github "RxSwiftCommunity/NSObject-Rx"
 ```
 Add frameworks to your project (no need to "copy items if needed")
 


### PR DESCRIPTION
catch up*

I've removed the missing HasDisposeBag.swift reference from the Xcode project so that the project compiles. Perhaps RxSwiftCommunity/NSObject-Rx/pull/49 can suitably add it back.