### PR TITLE
Add the public modifier access to the disposeBag property

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Changelog
 Current master
 --------------
 
-- Nothing yet!
+- Add the public modifier access to the disposeBag property. See [#74](https://github.com/RxSwiftCommunity/NSObject-Rx/pull/74) - [@Vkt0r](https://github.com/Vkt0r)
 
 5.0.1
 -----

--- a/HasDisposeBag.swift
+++ b/HasDisposeBag.swift
@@ -20,7 +20,7 @@ extension HasDisposeBag {
         return result
     }
 
-    var disposeBag: DisposeBag {
+    public var disposeBag: DisposeBag {
         get {
             return synchronizedBag {
                 if let disposeObject = objc_getAssociatedObject(self, &disposeBagContext) as? DisposeBag {


### PR DESCRIPTION
Hello guys 👋,

I just updated to `5.0.1` and the compiler was throwing the following exception:

>'disposeBag' is inaccessible due to 'internal' protection level

For any type implementing the `HasDisposeBag` protocol.  I saw that in #73, the `public` modifier access was removed. The extension is `internal` so the `public` accessor modifier shouldn't be removed if this want to be exposed as it was before.
 