### PR TITLE
Add HasDisposeBag.swift to SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             name: "NSObject-Rx",
             dependencies: ["RxSwift"],
             path: ".",
-            sources: ["NSObject+Rx.swift"]
+            sources: ["NSObject+Rx.swift", "HasDisposeBag.swift"]
         ),
     ]
 )


### PR DESCRIPTION
#trivial
We can't use `HasDisposeBag` when using SwiftPM.
So I added file source!
please review, thanks!