### PR TITLE
Add Support to RxSwift 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: "11.4.0"
+      xcode: "12.3.0"
 
     steps:
       - checkout

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 6.0.0
+github "ReactiveX/RxSwift" ~> 6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "6.0.0"
+github "ReactiveX/RxSwift" "6.1.0"

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Nimble (9.0.0)
-  - "NSObject+Rx (5.1.0)":
-    - RxSwift (~> 6.0.0)
-  - Quick (3.0.0)
-  - RxSwift (6.0.0)
+  - "NSObject+Rx (5.2.0)":
+    - RxSwift (~> 6.0)
+  - Quick (3.1.2)
+  - RxSwift (6.1.0)
 
 DEPENDENCIES:
   - Nimble
@@ -23,10 +23,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  "NSObject+Rx": d6db7585604967c8b2f754373eb3273b87a40328
-  Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
-  RxSwift: c14e798c59b9f6e9a2df8fd235602e85cc044295
+  "NSObject+Rx": d5aeadd891914d6e72765cd56421b4a6bcf8fdad
+  Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
+  RxSwift: a834e5c538e89eca0cae86f403f4fbf0336786ce
 
 PODFILE CHECKSUM: 4f420ecd33a82075e360098bbed0ccaadfeb1728
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.1

--- a/NSObject+Rx.podspec
+++ b/NSObject+Rx.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/RxSwiftCommunity/NSObject-Rx.git", :tag => s.version }
   s.source_files  = %w(NSObject+Rx.swift HasDisposeBag.swift)
   s.frameworks  = "Foundation"
-  s.dependency 'RxSwift', '~> 6.0.0'
+  s.dependency 'RxSwift', '~> 6.0'
 end


### PR DESCRIPTION
### Motivation and Context

When doing a `pod update` to update to RxSwift 6.10 (Ethan1) the `NSObject+Rx` reverts to `2.1.0` from `5.2.0` making `NSObject+Rx` break the build. 

### Description 
- Update podspect 
- Update CircleCI config
- Regenerate dependencies: `pod update` and `carthage update`
