### PR TITLE
#trivial Use `AnyObject` instead of `class`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Changelog
 Current master
 --------------
 
-- Nothing yet!
+- Use `AnyObject` instead of `class` keyword, which was deprecated since Swift 4. See [#93](https://github.com/RxSwiftCommunity/NSObject-Rx/pull/93) - [@tomisacat](https://github.com/tomisacat).
 
 5.2.2
 -----

--- a/HasDisposeBag.swift
+++ b/HasDisposeBag.swift
@@ -5,7 +5,7 @@ import ObjectiveC
 fileprivate var disposeBagContext: UInt8 = 0
 
 /// each HasDisposeBag offers a unique RxSwift DisposeBag instance
-public protocol HasDisposeBag: class {
+public protocol HasDisposeBag: AnyObject {
 
     /// a unique RxSwift DisposeBag instance
     var disposeBag: DisposeBag { get set }


### PR DESCRIPTION
`class` keyword is deprecated since Swift 4, use `AnyObject` instead. 