### PR TITLE
Set IPHONEOS_DEPLOYMENT_TARGET as 9.0

### DIFF
--- a/NSObject-Rx.xcodeproj/project.pbxproj
+++ b/NSObject-Rx.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "RxSwiftCommunity.NSObject-Rx";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -196,7 +196,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "RxSwiftCommunity.NSObject-Rx";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
RxSwift 6.2.0 has 9.0 as its deployment target.
NSObject-Rx's podspec has 9.0 also. https://github.com/RxSwiftCommunity/NSObject-Rx/blob/master/NSObject%2BRx.podspec#L13

I am trying to use NSObject-Rx via Carthage but failing because NSObject-Rx has lower deployment target than RxSwift 6.2.0 .